### PR TITLE
Updating plugin to err version 3.1

### DIFF
--- a/githubhook.py
+++ b/githubhook.py
@@ -5,7 +5,7 @@ import hmac
 import json
 import logging
 
-from errbot import BotPlugin, botcmd, webhook, holder
+from errbot import BotPlugin, botcmd, webhook
 from errbot.templating import tenv
 from config import BOT_PREFIX, CHATROOM_FN
 from bottle import abort, response
@@ -157,7 +157,7 @@ class GithubHook(BotPlugin):
         use !config GithubHook <configuration blob> to configure this
         plugin.
         """
-        holder.bot.set_plugin_configuration('GithubHook', self.config)
+        self._bot.set_plugin_configuration('GithubHook', self.config)
 
     def show_repo_config(self, repo):
         """Builds up a complete list of rooms and events for a repository."""

--- a/templates/commit_comment.html
+++ b/templates/commit_comment.html
@@ -1,4 +1,1 @@
-{% extends "base.html" %}
-{%- block body -%}
-[Github] [{{repo}}] commit <a href="{{url}}">{{sha|truncate(10, '…')}} {%- if line %} at line {{line}} {%- endif %}</a> commented on by {{user}}.
-{%- endblock -%}
+[Github] [{{repo}}] commit {{url}} {%- if line %} at line {{line}} {%- endif %} commented on by {{user}}.

--- a/templates/generic.html
+++ b/templates/generic.html
@@ -1,4 +1,1 @@
-{% extends "base.html" %}
-{%- block body -%}
 [Github] [{{repo}}] event of type: {{event_type}} received.
-{%- endblock -%}

--- a/templates/issue_comment.html
+++ b/templates/issue_comment.html
@@ -1,4 +1,1 @@
-{% extends "base.html" %}
-{%- block body -%}
-[Github] [{{repo}}] {{user}} {{action}} on issue <a href="{{url}}">#{{number}}</a> ({{title}}).
-{%- endblock -%}
+[Github] [{{repo}}] {{user}} {{action}} on issue {{url}} ({{title}}).

--- a/templates/issues.html
+++ b/templates/issues.html
@@ -1,19 +1,16 @@
-{% extends "base.html" %}
-{%- block body -%}
 {%- if action in ['opened', 'closed', 'reopened'] -%}
-  [Github] [{{repo}}] issue <a href="{{url}}">#{{number}}</a> ({{title}}) {{action}} by {{user}}.
+    [Github] [{{repo}}] issue {{url}} ({{title}}) {{action}} by {{user}}
 {%- elif action in ['labeled', 'unlabeled'] %}
-{%- if action == 'labeled' -%}
-    {%- set act_value = 'added to' -%}
-  {%- else -%}
-    {%- set act_value = 'removed from' -%}
-  {%- endif -%}
-  [Github] [{{repo}}] label {{act_value}} issue <a href="{{url}}">#{{number}}</a> ({{title}}) by {{user}}.
+    {%- if action == 'labeled' -%}
+        {%- set act_value = 'added to' -%}
+    {%- else -%}
+        {%- set act_value = 'removed from' -%}
+    {%- endif -%}
+    [Github] [{{repo}}] label {{act_value}} issue {{url}} ({{title}}) by {{user}}.
 {%- elif action == 'assigned' -%}
-  [Github] [{{repo}}] issue <a href="{{url}}">#{{number}}</a> ({{title}}) {{action}} to {{assignee}} by {{user}}.
+    [Github] [{{repo}}] issue {{url}} ({{title}}) {{action}} to {{assignee}} by {{user}}.
 {%- elif action == 'unassigned' -%}
-  [Github] [{{repo}}] issue <a href="{{url}}">#{{number}}</a> ({{title}}) {{action}} by {{user}}.
+    [Github] [{{repo}}] issue {{url}} ({{title}}) {{action}} by {{user}}.
 {%- else -%}
-  [Github] [{{repo}}] unknown action: {{action}} for event type: issue received.
+    [Github] [{{repo}}] unknown action: {{action}} for event type: issue received.
 {%- endif -%}
-{%- endblock -%}

--- a/templates/pull_request.html
+++ b/templates/pull_request.html
@@ -1,4 +1,1 @@
-{% extends "base.html" %}
-{%- block body -%}
-[Github] [{{repo}}] pull request <a href="{{url}}">#{{number}}</a> {{action}} by {{user}}.
-{%- endblock -%}
+[Github] [{{repo}}] pull request {{url}} {{action}} by {{user}}.

--- a/templates/pull_request_review_comment.html
+++ b/templates/pull_request_review_comment.html
@@ -1,4 +1,1 @@
-{% extends "base.html" %}
-{%- block body -%}
-[Github] [{{repo}}] {{user}} {{action}} on <a href="{{l_url}}">line {{line}}</a> in pull request <a href="{{url}}">#{{pr}}</a>.
-{%- endblock -%}
+[Github] [{{repo}}] {{user}} {{action}} on {{l_url}} line {{line}} in pull request {{url}}.

--- a/templates/push.html
+++ b/templates/push.html
@@ -1,9 +1,6 @@
-{% extends "base.html" %}
-{%- block body -%}
 {%- if commits == 1 -%}
   {%- set commit = 'commit' -%}
 {%- else -%}
   {%- set commit = 'commits' -%}
 {%- endif -%}
-[Github] [{{repo}}] {{commits}} {{commit}} pushed to <a href="{{url}}">{{branch}}</a> by {{user}}.
-{%- endblock -%}
+[Github] [{{repo}}] {{commits}} {{commit}} pushed to {{url}} - {{branch}} by {{user}}.


### PR DESCRIPTION
holder has been removed from err backends.

In order to set the plugin configuration self._bot is now used.

Because they disabled html rendering I updated all the templates
to use a more simplified version of the templates
