### PR TITLE
fix: Fix save_config

### DIFF
--- a/githubhook.py
+++ b/githubhook.py
@@ -157,7 +157,8 @@ class GithubHook(BotPlugin):
         use !config GithubHook <configuration blob> to configure this
         plugin.
         """
-        self._bot.set_plugin_configuration('GithubHook', self.config)
+        self._bot.plugin_manager.set_plugin_configuration('GithubHook',
+                                                          self.config)
 
     def show_repo_config(self, repo):
         """Builds up a complete list of rooms and events for a repository."""


### PR DESCRIPTION
- The save_config function used the old way of saving config for a
  plugin. This commit makes sure it uses the correct one, which could be
  find in the core errbot code at the time of writing of this commit
  message.
- Fixes #2.

Signed-off-by: mr.Shu mr@shu.io

---

@daenney @Eagllus This kind of does what #1 did at its time. The relevant line of errbot's core code is this one: https://github.com/errbotio/errbot/blob/master/errbot/core_plugins/plugins.py#L185

Do let me know if you have any questions.

Thanks!
