### PR TITLE
Remove the deprecated message_type argument of the send function

### DIFF
--- a/repohook.py
+++ b/repohook.py
@@ -408,7 +408,7 @@ class RepoHook(BotPlugin):
                     identifier = self.build_identifier(room)
                     if hasattr(self, 'join_room'):
                         self.join_room(identifier, username=config.CHATROOM_FN)
-                    self.send(identifier, message, message_type='groupchat')
+                    self.send(identifier, message)
         response.status = 204
         return None
 

--- a/repohook.py
+++ b/repohook.py
@@ -28,7 +28,7 @@ README = 'https://github.com/daenney/err-repohook/blob/master/README.rst'
 
 class RepoHook(BotPlugin):
 
-    min_err_version = '2.1.0'
+    min_err_version = '5.0.0'
 
     def __init__(self, *args, **kwargs):
         super(RepoHook, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Without this change, the bot tracebacks everytime it tries to send a message
to a room, making the plugin completely broken.

See http://errbot.io/en/latest/errbot.botplugin.html#errbot.botplugin.BotPlugin.send